### PR TITLE
Make it unabusable

### DIFF
--- a/ftc-library/src/main/java/com/lasarobotics/library/util/Constants.java
+++ b/ftc-library/src/main/java/com/lasarobotics/library/util/Constants.java
@@ -3,6 +3,9 @@ package com.lasarobotics.library.util;
 /**
  * Created by Ehsan on 7/12/2015.
  */
-public class Constants {
+public final class Constants {
+    private Constants() {
+        throw new AssertionError();
+    }
     public static final long MONKEYC_STARTING_CONSTANT = -1000;
 }


### PR DESCRIPTION
I'd say its best to create the constants in the actual class where they are most relevant, but if this has to be done, then it should at least be safe from instantiation and from having child classes extending it. If you accept this change, do note that it will need to be a static import in other classes when being used.
