### PR TITLE
Treat Vector3 like struct

### DIFF
--- a/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
+++ b/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
@@ -1,7 +1,7 @@
 package com.lasarobotics.library.util;
 
 /**
- * 3D Vector
+ * 3D Vector : Immutable
  */
 public class Vector3<T> {
     public final T x;
@@ -26,8 +26,9 @@ public class Vector3<T> {
             return this;
         }
         
+        // Illegal State Exception errors can be thrown if x, y, or z is null
         public Vector3<T> build() { 
-            return new Vector3<T>(x, y, x);
+            return new Vector3<T>(x, y, z);
         }
     }
 

--- a/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
+++ b/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
@@ -9,6 +9,7 @@ public class Vector3<T> {
     public final T z;
     
     public static class Builder<T> {
+        private final T x, y, z;
         
         public Builder x(T n) {
             this.x = n;

--- a/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
+++ b/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
@@ -11,17 +11,17 @@ public class Vector3<T> {
     public static class Builder<T> {
         private final T x, y, z;
         
-        public Builder x(T n) {
+        public Builder<T> x(T n) {
             this.x = n;
             return this;
         }
         
-        public Builder y(T n) {
+        public Builder<T> y(T n) {
             this.y = n;
             return this;
         }
         
-        public Builder z(T n) {
+        public Builder<T> z(T n) {
             this.z = n;
             return this;
         }

--- a/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
+++ b/ftc-library/src/main/java/com/lasarobotics/library/util/Vector3.java
@@ -4,20 +4,37 @@ package com.lasarobotics.library.util;
  * 3D Vector
  */
 public class Vector3<T> {
-    private T x;
-    private T y;
-    private T z;
+    public final T x;
+    public final T y;
+    public final T z;
+    
+    public static class Builder<T> {
+        
+        public Builder x(T n) {
+            this.x = n;
+            return this;
+        }
+        
+        public Builder y(T n) {
+            this.y = n;
+            return this;
+        }
+        
+        public Builder z(T n) {
+            this.z = n;
+            return this;
+        }
+        
+        public Vector3<T> build() { 
+            return new Vector3<T>(x, y, x);
+        }
+    }
 
-    public Vector3(T x, T y, T z)
-    {
+    public Vector3(T x, T y, T z) {
         this.x = x;
         this.y = y;
         this.z = z;
     }
-
-    public T x() { return x; }
-    public T y() { return y; }
-    public T z() { return z; }
 
     @Override
     public String toString() {


### PR DESCRIPTION
This is not a 100% necessary change, but it will improve the easy of usability of these Vectors. Using the builder class, you can say `new Vector.Builder<Integer>().x(5).y(4).z(5).build()` to build a vector, and then to call the vector's variables, you can directly access them: `vector.x`. This will cause the class to be treated more like a struct would be in C/C++, which would make sense considering that it's only purpose is to hold data. Hence, the purpose of this change is ease of usability, and to make the vector immutable. 

NOTE: I submitted this on a machine without the ability to compile java, so there may be some small errors you need to fix because I didn't get to see how this affected run-time or compiler warnings. I recommend checking that out if you are interested in merging this pull.
